### PR TITLE
Remove unneeded Type import from typing

### DIFF
--- a/eth_keys/backends/__init__.py
+++ b/eth_keys/backends/__init__.py
@@ -1,7 +1,4 @@
 import os
-from typing import (
-    Type,
-)
 
 from eth_keys.utils.module_loading import (
     import_string,

--- a/newsfragments/110.internal.rst
+++ b/newsfragments/110.internal.rst
@@ -1,0 +1,1 @@
+Remove unneeded from typing import Type in eth_keys/backends/__init__.py


### PR DESCRIPTION
### What was wrong?
I was going too fast and missed a removal of Type from the typing module. I assume that lint didn't catch this because it was an `__init__.py` file, but not 100% sure. Can look into it if desired. 

### How was it fixed?
Removed!

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-keys/blob/main/newsfragments/README.md)

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://home.adelphi.edu/~ap21473/Cute%20otter.jpg)
